### PR TITLE
Fix markup mistake in meta.yaml [ci skip]

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,4 +42,4 @@ about:
 
 extra:
   recipe-maintainers:
-    pkgw
+    - pkgw


### PR DESCRIPTION
Uncaught typo in the meta.yaml.